### PR TITLE
Pass the channel name to the bot channel data

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -24,6 +24,7 @@ type ChannelData struct {
 	Protocol  string // What protocol the message was sent on (irc, slack, telegram)
 	Server    string // The server hostname the message was sent on
 	Channel   string // The channel name the message appeared in
+	HumanName string // The human readable name of the channel.
 	IsPrivate bool   // Whether the channel is a group or private chat
 }
 

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -152,6 +152,7 @@ Loop:
 							Protocol:  "slack",
 							Server:    teaminfo.Domain,
 							Channel:   channel,
+							HumanName: C.Name,
 							IsPrivate: !C.IsChannel,
 						},
 						extractText(ev),


### PR DESCRIPTION
This makes it much easier to act on which channel the message
is coming from.